### PR TITLE
feature/adicionar-notificacao-transferencia-recebida-ao-fluxo-de-transferencia

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 
 # Desafio Pagamento Simplificado (Versão Laravel 10)
 
-<span style="color: red; font-weight: bold;">EM CONSTRUÇÃO</span>
-
 ## Descrição do desafio
 
 O objetivo deste desafio é construir uma API RESTFul para efetuar pagamentos simples. Nela deve ser possível realizar transferências de dinheiro entre usuários. Temos 2 tipos de usuários: os *comuns* e os *lojistas*, sendo que ambos possuem carteira com dinheiro e realizam transferências entre eles.

--- a/app/Domain/Transfer/Events/TransferReceived.php
+++ b/app/Domain/Transfer/Events/TransferReceived.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Domain\Transfer\Events;
+
+use App\Domain\Transfer\Models\Transfer;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class TransferReceived
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Transfer $transfer)
+    {
+    }
+}

--- a/app/Domain/Transfer/Listeners/SendTransferReceivedNotifications.php
+++ b/app/Domain/Transfer/Listeners/SendTransferReceivedNotifications.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Domain\Transfer\Listeners;
+
+use App\Domain\Transfer\Events\TransferReceived;
+use App\Domain\Transfer\Notifications\TransferReceivedNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class SendTransferReceivedNotifications implements ShouldQueue
+{
+    /**
+     * The name of the connection the job should be sent to.
+     *
+     * @var string|null
+     */
+    public $connection = 'redis';
+
+    /**
+     * The name of the queue the job should be sent to.
+     *
+     * @var string|null
+     */
+    public $queue = 'notifications';
+
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(TransferReceived $event): void
+    {
+        $user = $event->transfer->payee;
+        $user->notify(new TransferReceivedNotification($event->transfer));
+    }
+
+    /**
+     * Handle event failure.
+     */
+    public function failed(TransferReceived $event, Throwable $exception): void
+    {
+        Log::error(
+            '[SendTransferReceivedNotifications] Failed to send notifications through the event TransferReceived.',
+            [
+                'error_message' => $exception->getMessage(),
+                'file' => $exception->getFile(),
+                'line' => $exception->getLine(),
+                'data' => [
+                    'event' => get_class($event),
+                    'transfer' => $event->transfer ?? null
+                ],
+                'stack_trace' => $exception->getTrace()
+            ]
+        );
+    }
+}

--- a/app/Domain/Transfer/Notifications/TransferReceivedNotification.php
+++ b/app/Domain/Transfer/Notifications/TransferReceivedNotification.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Domain\Transfer\Notifications;
+
+use App\Domain\Transfer\Models\Transfer;
+use Illuminate\Notifications\Notification;
+
+class TransferReceivedNotification extends Notification
+{
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(protected Transfer $transfer)
+    {
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['ext_notifier'];
+    }
+
+    /**
+     * Get the ext_notifier representation of the notification.
+     */
+    public function toExtNotifier(object $notifiable): array
+    {
+        return [
+            'recipient' => $notifiable->email,
+            'message' => sprintf(
+                config('transfer.notification_messages.transfer_received'),
+                $this->transfer->payer->name,
+                $this->transfer->amount
+            )
+        ];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [];
+    }
+}

--- a/app/Domain/Transfer/Services/TransferService.php
+++ b/app/Domain/Transfer/Services/TransferService.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Domain\Transfer\DataTransferObjects\CreateTransferDto;
 use App\Domain\Transfer\Enums\TransferStatusEnum;
+use App\Domain\Transfer\Events\TransferReceived;
 use App\Domain\Transfer\Exceptions\TransferFailedException;
 use App\Domain\Transfer\Exceptions\UnauthorizedTransferException;
 use App\Domain\Transfer\Models\Transfer;
@@ -115,7 +116,7 @@ class TransferService implements TransferServiceInterface
 
             DB::commit();
 
-            // TODO: Incluir evento de notificação para PAYEE. Exemplo: event(new TransferReceived($user));
+            event(new TransferReceived($processedTransfer));
 
             return $processedTransfer;
         } catch (Throwable $exception) {

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -7,6 +7,8 @@ use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Notifications\Events\NotificationSent;
 use App\Domain\Notification\Listeners\RegisterNotification;
+use App\Domain\Transfer\Events\TransferReceived;
+use App\Domain\Transfer\Listeners\SendTransferReceivedNotifications;
 use App\Domain\User\Events\UserCreated;
 use App\Domain\User\Listeners\SendUserCreatedNotifications;
 
@@ -26,6 +28,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         UserCreated::class => [
             SendUserCreatedNotifications::class
+        ],
+        TransferReceived::class => [
+            SendTransferReceivedNotifications::class
         ]
     ];
 

--- a/config/transfer.php
+++ b/config/transfer.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'notification_messages' => [
+        'transfer_received' => 'Transferência recebida! O usuário %s enviou uma transferência para você no valor de R$ %.2f.',
+    ]
+];

--- a/docs/answering_challenge.md
+++ b/docs/answering_challenge.md
@@ -41,7 +41,7 @@ php artisan queue:work --queue=notifications
 
 Com isso a aplicação ficará em estado de espera, ou seja, aguardando que ações sejam colocadas na fila para serem executadas. Caso já existam ações armazenadas, elas serão devidamente processadas. Se você deseja interromper o estado de espera da aplicação, basta utilizar a seguinte combinação de teclas no terminal: `ctrl + c` .
 
-As notificações são disparadas por diferentes canais, mas seu comportamento é modificado para apenas simular os envios visto que não estamos em ambiente de produção. Os envios simulados registram informações em logs e também na entidade `notifications` do banco de dados.
+As notificações são disparadas por diferentes canais, mas **seu comportamento é modificado para apenas simular os envios** visto que não estamos em ambiente de produção. Os envios simulados registram informações em **logs** e também na entidade `notifications` do banco de dados.
 
 ### Explicação da API
 

--- a/tests/Feature/Transfer/CreateTransferTest.php
+++ b/tests/Feature/Transfer/CreateTransferTest.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
 use App\Domain\ApiUser\Models\ApiUser;
 use App\Domain\Transfer\Enums\TransferStatusEnum;
+use App\Domain\Transfer\Events\TransferReceived;
 use App\Domain\TransferAuthorization\Services\Interfaces\TransferAuthorizerServiceInterface;
 use App\Domain\User\Enums\UserTypeEnum;
 use App\Domain\User\Models\User;
@@ -59,20 +60,21 @@ class CreateTransferTest extends TestCase
         $payer = User::find(1);
         $payee = User::find(2);
 
-        $payerExpectedWalletBalance = $payer->wallet->balance - 20.50;
-        $payeeExpectedWalletBalance = $payee->wallet->balance + 20.50;
+        $transferAmount = 20.50;
+        $payerExpectedWalletBalance = $payer->wallet->balance - $transferAmount;
+        $payeeExpectedWalletBalance = $payee->wallet->balance + $transferAmount;
 
         $data = [
             'payer' => $payer->id,
             'payee' => $payee->id,
-            'value' => 20.50
+            'value' => $transferAmount
         ];
 
         $this->transferAuthorizationServiceMock->shouldReceive('authorize')->once()->andReturn(true);
 
         $response = $this->postJson(route('transfer.create'), $data);
 
-        // TODO: Testar evento de notificação para PAYEE. Exemplo: Event::assertDispatched(TransferReceived::class);
+        Event::assertDispatched(TransferReceived::class);
 
         $response->assertStatus(Response::HTTP_CREATED);
         $response->assertJsonStructure([
@@ -129,20 +131,21 @@ class CreateTransferTest extends TestCase
         $payer = User::find(1);
         $payee = User::find(3);
 
-        $payerExpectedWalletBalance = $payer->wallet->balance - 100;
-        $payeeExpectedWalletBalance = $payee->wallet->balance + 100;
+        $transferAmount = 100;
+        $payerExpectedWalletBalance = $payer->wallet->balance - $transferAmount;
+        $payeeExpectedWalletBalance = $payee->wallet->balance + $transferAmount;
 
         $data = [
             'payer' => $payer->id,
             'payee' => $payee->id,
-            'value' => 100
+            'value' => $transferAmount
         ];
 
         $this->transferAuthorizationServiceMock->shouldReceive('authorize')->once()->andReturn(true);
 
         $response = $this->postJson(route('transfer.create'), $data);
 
-        // TODO: Testar evento de notificação para PAYEE. Exemplo: Event::assertDispatched(TransferReceived::class);
+        Event::assertDispatched(TransferReceived::class);
 
         $response->assertStatus(Response::HTTP_CREATED);
         $response->assertJsonStructure([

--- a/tests/Unit/App/Domain/Transfer/Listeners/SendTransferReceivedNotificationsTest.php
+++ b/tests/Unit/App/Domain/Transfer/Listeners/SendTransferReceivedNotificationsTest.php
@@ -28,6 +28,13 @@ class SendTransferReceivedNotificationsTest extends TestCase
         $this->seed(UserTypeSeeder::class);
     }
 
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
     /**
      * @group listeners
      * @group transfer
@@ -86,5 +93,7 @@ class SendTransferReceivedNotificationsTest extends TestCase
 
         $listener = new SendTransferReceivedNotifications();
         $result = $listener->failed($eventMock, $fakeException);
+
+        $this->assertTrue(empty($result));
     }
 }

--- a/tests/Unit/App/Domain/Transfer/Listeners/SendTransferReceivedNotificationsTest.php
+++ b/tests/Unit/App/Domain/Transfer/Listeners/SendTransferReceivedNotificationsTest.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace Tests\Unit\App\Domain\User\Listeners;
+namespace Tests\Unit\App\Domain\Transfer\Listeners;
 
-use App\Domain\User\Events\UserCreated;
-use App\Domain\User\Listeners\SendUserCreatedNotifications;
-use App\Domain\User\Models\User;
-use App\Domain\User\Notifications\WelcomeNotification;
+use App\Domain\Transfer\Events\TransferReceived;
+use App\Domain\Transfer\Listeners\SendTransferReceivedNotifications;
+use App\Domain\Transfer\Models\Transfer;
+use App\Domain\Transfer\Notifications\TransferReceivedNotification;
 use Database\Seeders\DocumentTypeSeeder;
+use Database\Seeders\TransferStatusSeeder;
 use Database\Seeders\UserTypeSeeder;
 use Exception;
 use Illuminate\Support\Facades\Event;
@@ -16,57 +17,58 @@ use Mockery;
 use Mockery\MockInterface;
 use Tests\TestCase;
 
-class SendUserCreatedNotificationsTest extends TestCase
+class SendTransferReceivedNotificationsTest extends TestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->seed(DocumentTypeSeeder::class);
+        $this->seed(TransferStatusSeeder::class);
         $this->seed(UserTypeSeeder::class);
     }
 
     /**
      * @group listeners
-     * @group user
+     * @group transfer
      */
     public function test_is_attached_to_event(): void
     {
         Event::fake();
         Event::assertListening(
-            UserCreated::class,
-            SendUserCreatedNotifications::class
+            TransferReceived::class,
+            SendTransferReceivedNotifications::class
         );
     }
 
     /**
      * @group listeners
-     * @group user
+     * @group transfer
      */
     public function test_it_send_notifications(): void
     {
         Notification::fake();
  
-        $user = User::factory()->create();
+        $transfer = Transfer::factory()->create();
 
-        $event = new UserCreated($user);
-        $listener = new SendUserCreatedNotifications();
+        $event = new TransferReceived($transfer);
+        $listener = new SendTransferReceivedNotifications();
         $listener->handle($event);
  
-        Notification::assertSentTo($user, WelcomeNotification::class);
+        Notification::assertSentTo($transfer->payee, TransferReceivedNotification::class);
     }
 
     /**
      * @group listeners
-     * @group user
+     * @group transfer
      */
     public function test_it_logs_if_event_fails(): void
     {
-        $user = User::factory()->create();
+        $transfer = Transfer::factory()->create();
 
-        /** @var MockInterface|UserCreated $eventMock */
-        $eventMock = Mockery::mock(UserCreated::class);
-        $eventMock->user = $user;
+        /** @var MockInterface|TransferReceived $eventMock */
+        $eventMock = Mockery::mock(TransferReceived::class);
+        $eventMock->transfer = $transfer;
 
         $fakeException = new Exception('Houston, we have a problem.');
 
@@ -75,14 +77,14 @@ class SendUserCreatedNotificationsTest extends TestCase
             ->withArgs(function ($message, $context) use($eventMock) {
                 return strpos(
                         $message,
-                        '[SendUserCreatedNotifications] Failed to send notifications through the event UserCreated.'
+                        '[SendTransferReceivedNotifications] Failed to send notifications through the event TransferReceived.'
                     ) !== false
                     && strpos($context['error_message'], 'Houston, we have a problem.') !== false
                     && $context['data']['event'] === get_class($eventMock)
-                    && $context['data']['user'] === $eventMock->user;
+                    && $context['data']['transfer'] === $eventMock->transfer;
             });
 
-        $listener = new SendUserCreatedNotifications();
+        $listener = new SendTransferReceivedNotifications();
         $result = $listener->failed($eventMock, $fakeException);
     }
 }

--- a/tests/Unit/App/Domain/Transfer/Notifications/TransferReceivedNotificationTest.php
+++ b/tests/Unit/App/Domain/Transfer/Notifications/TransferReceivedNotificationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit\App\Domain\Transfer\Notifications;
+
+use App\Domain\Transfer\Models\Transfer;
+use App\Domain\Transfer\Notifications\TransferReceivedNotification;
+use Database\Seeders\DocumentTypeSeeder;
+use Database\Seeders\TransferStatusSeeder;
+use Database\Seeders\UserTypeSeeder;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class TransferReceivedNotificationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(DocumentTypeSeeder::class);
+        $this->seed(TransferStatusSeeder::class);
+        $this->seed(UserTypeSeeder::class);
+    }
+
+    /**
+     * @group notifications
+     * @group transfer
+     */
+    public function test_is_sent_by_ext_notifier(): void
+    {
+        Notification::fake();
+
+        $transfer = Transfer::factory()->create();
+        $user = $transfer->payee;
+
+        $user->notify(new TransferReceivedNotification($transfer));
+
+        Notification::assertSentTo($user, TransferReceivedNotification::class, function ($notification, $channels) {
+            return in_array('ext_notifier', $channels);
+        });
+    }
+}

--- a/tests/Unit/App/Domain/User/Listeners/SendUserCreatedNotificationsTest.php
+++ b/tests/Unit/App/Domain/User/Listeners/SendUserCreatedNotificationsTest.php
@@ -84,5 +84,7 @@ class SendUserCreatedNotificationsTest extends TestCase
 
         $listener = new SendUserCreatedNotifications();
         $result = $listener->failed($eventMock, $fakeException);
+
+        $this->assertTrue(empty($result));
     }
 }


### PR DESCRIPTION
Implementar notificação de transferência recebida para quando uma transferência for efetivada.
A notificação deve ser disparada para o usuário que está recebendo o montante.